### PR TITLE
Update dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ on 'test' => sub {
   requires "File::Spec" => "0";
   requires "File::Temp" => "0";
   requires "IO::Handle" => "0";
+  requires "IO::Socket::SSL" => "0";
   requires "IPC::Open3" => "0";
   requires "String::Random" => "0";
   requires "Test::Class" => "0";

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires "Carp" => "0";
 requires "HTTP::Request::Common" => "0";
-requires "HTTP::Tiny" => "0";
+requires "HTTP::Tiny" => "0.056";
 requires "JSON" => "0";
 requires "parent" => "0";
 requires "perl" => "5.006";


### PR DESCRIPTION
There are 2 error found on cpantester, 
1. 
`Failed test 'shutdown died (malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "IO::Socket::SSL must...") at /home/cpan/pit/bare/conf/perl-5.16.1/.cpanplus/5.16.1/build/WebService-SendGrid-Newsletter-0.01/blib/lib/WebService/SendGrid/Newsletter.pm line 58.)' at t/01-schedule.t line 122.`
- fixed by require IO::Socket::SSL

2.
`Failed test 'startup died (Can't locate object method "post_form" via package "HTTP::Tiny" at /home/cpan/pit/thr/conf/perl-5.14.0/.cpanplus/5.14.0/build/WebService-SendGrid-Newsletter-0.01/blib/lib/WebService/SendGrid/Newsletter.pm line 55.)'  at t/01-categories.t line 97.
`
- I noticed that the version the failed test machine has HTTP::Tiny version 0.012 then I tried to use that version and ran the test again and got the same error. I assume that because HTTP::Tiny version is too old so I added require latest version on the second commit
